### PR TITLE
fix: pin Werkzeug 2.2.2 to match Flask 2.2.2

### DIFF
--- a/orders-service-api/requirements.txt
+++ b/orders-service-api/requirements.txt
@@ -1,3 +1,4 @@
 pinotdb==0.4.5
 flask==2.2.2
 flask-cors==3.0.10
+Werkzeug==2.2.2


### PR DESCRIPTION
# Description

Pin `orders-service-api`'s Werkzeug library to version 2.2.2 in order to match pinned version of Flask (2.2.2).

Without pinning Werkzeug, running `docker compose -f docker-compose-base.yml` up picks up Werkzeug 3.x and results in the following error:

```python
orders-service-api                | Traceback (most recent call last):
orders-service-api                |   File "/usr/local/lib/python3.9/runpy.py", line 188, in _run_module_as_main
orders-service-api                |     mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
orders-service-api                |   File "/usr/local/lib/python3.9/runpy.py", line 147, in _get_module_details
orders-service-api                |     return _get_module_details(pkg_main_name, error)
orders-service-api                |   File "/usr/local/lib/python3.9/runpy.py", line 111, in _get_module_details
orders-service-api                |     __import__(pkg_name)
orders-service-api                |   File "/opt/venv/lib/python3.9/site-packages/flask/__init__.py", line 5, in <module>
orders-service-api                |     from .app import Flask as Flask
orders-service-api                |   File "/opt/venv/lib/python3.9/site-packages/flask/app.py", line 30, in <module>
orders-service-api                |     from werkzeug.urls import url_quote
orders-service-api                | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/opt/venv/lib/python3.9/site-packages/werkzeug/urls.py)
orders-service-api exited with code 1
```

I tested this fix locally and I no longer get errors from the `orders-service-api` service.